### PR TITLE
Fixed bug with Power input

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -19,7 +19,10 @@ def pickLevel():
 
     currentLevel.clear()
     
-    currentLevel.load(filename)
+    try:
+        currentLevel.load(filename)
+    except FileNotFoundError as fnf:
+        print(fnf)
 
 def newLevel():
     currentLevel.clear()

--- a/editor.py
+++ b/editor.py
@@ -89,12 +89,12 @@ for index,but in enumerate(b):
 currentEntity = None
 
 def input(key):
-    if len(info) == 2 and info[1].active :
-        updateElem(currentEntity)
+    if len(info) == 2 and info[1].active:
+        try:    
+            updateElem(currentEntity)
+        except ValueError as ve:
+            print(ve)
     else :
-        if key == "a down":
-            print("woah")
-
         if key == 'scroll down':
             camera.fov += (0.75 * 250 * time.dt)
 


### PR DESCRIPTION
Fixed `ValueError: could not convert string to float` when using backspace on empty input box.

Uses try/except block, stores error as `ve` for further debugging purpose